### PR TITLE
fix: Adding z-index to portrait-hud parent element

### DIFF
--- a/styles/PortraitHUD.css
+++ b/styles/PortraitHUD.css
@@ -14,6 +14,7 @@
     position: relative;
     transition: all 0.3s ease-in-out;
     pointer-events: all;
+    z-index: 1;
 }
 
 .portrait-hud-image{


### PR DESCRIPTION
**ALL OTHER MODULES DISABLED?**: True

**Module:** Argon - Combat HUD v0.1

**Conflicting Module (if applicable)**:  NA

**Foundry and System version**: Foundry 0.8.9 DnD5e 1.5.5

**OS, Hosting, Browser (if applicable)**: Windows 11, Firefox 102.0 (64-bit)

**Short Description of bug**:

The portrait-hud overlay covers the image being shown in it, due to a z-index issue.

While I know that this module isn't supporting anything other than Chrome, this is a simple fix for Firefox that won't break anything in Chrome.

**Simple steps to reproduce the bug**:

Launch Foundry with this module enabled, and view a character profile with an image.

**Screenshots and/or console errors**:

Without fix:
![Screenshot 2022-07-05 224319](https://user-images.githubusercontent.com/20833/177423903-94b19eae-719a-4e54-8575-8efb693f3597.png)

With fix:
![Screenshot 2022-07-05 224353](https://user-images.githubusercontent.com/20833/177423924-ec4e3ee4-1f0e-4ed7-8f7b-41db49986809.png)