### PR TITLE
[AutoEquip] When switching sets, only unequip non-active sets

### DIFF
--- a/scripts/ExtendedCombatHud.js
+++ b/scripts/ExtendedCombatHud.js
@@ -411,18 +411,24 @@ class CombatHud {
       await this.actor.setFlag("enhancedcombathud", "activeSet", active);
       return;
     }
-    if (this.sets.set1.primary?.system.equipped)
-      await this.sets.set1.primary?.update({ "data.equipped": false });
-    if (this.sets.set1.secondary?.system.equipped)
-      await this.sets.set1.secondary?.update({ "data.equipped": false });
-    if (this.sets.set2.primary?.system.equipped)
-      await this.sets.set2.primary?.update({ "data.equipped": false });
-    if (this.sets.set2.secondary?.system.equipped)
-      await this.sets.set2.secondary?.update({ "data.equipped": false });
-    if (this.sets.set3.primary?.system.equipped)
-      await this.sets.set3.primary?.update({ "data.equipped": false });
-    if (this.sets.set3.secondary?.system.equipped)
-      await this.sets.set3.secondary?.update({ "data.equipped": false });
+    if (active !== 'set1') {
+      if (this.sets.set1.primary?.system.equipped)
+        await this.sets.set1.primary?.update({ "data.equipped": false });
+      if (this.sets.set1.secondary?.system.equipped)
+        await this.sets.set1.secondary?.update({ "data.equipped": false });
+    }
+    if (active !== 'set2') {
+      if (this.sets.set2.primary?.system.equipped)
+        await this.sets.set2.primary?.update({ "data.equipped": false });
+      if (this.sets.set2.secondary?.system.equipped)
+        await this.sets.set2.secondary?.update({ "data.equipped": false });
+    }
+    if (active !== 'set3') {
+      if (this.sets.set3.primary?.system.equipped)
+        await this.sets.set3.primary?.update({ "data.equipped": false });
+      if (this.sets.set3.secondary?.system.equipped)
+        await this.sets.set3.secondary?.update({ "data.equipped": false });
+    }
     //this.sets.active = this.sets[active];
     await this.actor.setFlag("enhancedcombathud", "activeSet", active);
     if (!this.sets.active.primary?.system.equipped)


### PR DESCRIPTION
**I have disabled all other modules: **True (except Item Macro)
**Conflicting Module(s): **Item Macro
**Foundry and System version: **Foundry 9.269, DnD 1.6.3
**OS, Hosting, Browser (if applicable): **Windows 10, Chrome

This change removes unnecessary unequip calls, particularly when the HUD is first opened, and avoids potential issues with item macros that trigger on equip/unequip.

Example scenario on current branch:
- PC has a moon-touched weapon equipped before combat.  This weapon has an item macro that toggles the token's light radius on/off on equip/unequip.
- Combat begins, and the PC opens Argon Combat HUD and has the moon-touched weapon as their default active set.
- If Auto Equip is enabled, this will cause the weapon to unequip and re-equip very quickly, triggering the unequip macro.  In the best case, it will also trigger the equip macro immediately after, but in the worst case (which I was experiencing in my game), only the unequip macro will trigger, potentially leading to weird scenarios where an item is equipped, but its associated effect is not active.