### PR TITLE
Optional ids for spans of portrait statblocks

### DIFF
--- a/scripts/core/components/portrait/portraitPanel.js
+++ b/scripts/core/components/portrait/portraitPanel.js
@@ -120,6 +120,7 @@ export class PortraitPanel extends ArgonComponent {
         const span = document.createElement("span");
         span.innerText = stat.text;
         span.style.color = stat.color;
+        if (stat.id != undefined) span.id = stat.id;
         sb.appendChild(span);
       }
       this.element.appendChild(sb);


### PR DESCRIPTION
A small addition to make spans of statblocks and statblocks themselves easier to identify. Usefull for situations where very small parts of the ui need to updated or events need to be added to the spans/statsblocks.