### PR TITLE
Per case colors for tooltips

### DIFF
--- a/templates/partials/Tooltip.hbs
+++ b/templates/partials/Tooltip.hbs
@@ -3,7 +3,7 @@
     <h2>{{title}}</h2>
   </div>
   <div class="ech-tooltip-body">
-    {{#if subtitle}}<h4 class="ech-tooltip-subtitle">{{subtitle}}</h4>{{/if}}
+    {{#if subtitle}}<h4 class="ech-tooltip-subtitle" {{#if subtitlecolor}} style="background-color:{{subtitlecolor}}" {{/if}}>{{subtitle}}</h4>{{/if}}
     <div class="ech-tooltip-description">{{{description}}}</div>
     <div class="ech-tooltip-details">
       {{#each details}}
@@ -19,9 +19,9 @@
       {{#each properties as |property|}}
       {{#if property.label}}
       {{#if property.isPrimary}}
-      <span class="ech-tooltip-badge damt">{{{localize property.label}}}</span>
+      <span class="ech-tooltip-badge damt" {{#if property.color}} style="background-color:{{property.color}}" {{/if}}>{{{localize property.label}}}</span>
       {{else}}
-      <span class="ech-tooltip-badge prop">{{{localize property.label}}}</span>
+      <span class="ech-tooltip-badge prop" {{#if property.color}} style="background-color:{{property.color}}" {{/if}}>{{{localize property.label}}}</span>
       {{/if}}
       {{/if}}
       {{/each}}


### PR DESCRIPTION
A small change for subtitles and properties of tooltips to have a per case color setting. Allows the colors of these elements to be used to show item properties like e.g. rarity