### PR TITLE
Add key to pin tooltips

### DIFF
--- a/languages/de.json
+++ b/languages/de.json
@@ -191,6 +191,14 @@
       "movementBaseMovement": "Hintergrund/Boxschatten des Kastens der verfügbare Bewegungsfelder darstellt",
       "movementDashMovement": "Hintergrund/Boxschatten des Kastens der Spurt-Bewegungsfelder darstellt",
       "movementDangerMovement": "Hintergrund/Boxschatten des Kastens der überschrittene Bewegungsfelder darstellt"
-    }
+    },
+    "hotkey": {
+      "toggle": {
+        "name": "Argon Combat HUD umschalten"
+      },
+      "pinTooltip": {
+        "name": "Tooltips anpinnen"
+      }
+    },
   }
 }

--- a/languages/en.json
+++ b/languages/en.json
@@ -230,6 +230,9 @@
     "hotkey": {
       "toggle": {
         "name": "Toggle Argon Combat HUD"
+      },
+      "pinTooltip": {
+        "name": "Pin tooltip"
       }
     },
     "err": {

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -639,4 +639,14 @@ export function registerKeybindings() {
             ui.ARGON.toggle();
         },
     });
+
+    game.keybindings.register("enhancedcombathud", "pinTooltip", {
+        name: "enhancedcombathud.hotkey.pinTooltip.name",
+        editable: [{ key: "AltLeft"}],
+        restricted: false,
+        onDown: () => {},
+        onUp: () => {
+            Hooks.call("argon-releaseTooltip");
+        },
+    });
 }

--- a/scripts/core/components/component.js
+++ b/scripts/core/components/component.js
@@ -106,9 +106,24 @@ export class ArgonComponent {
     }
 
     async _onTooltipMouseLeave(event) {
-        if (!this._tooltip) return;
-        this._tooltip._destroy();
-        this._tooltip = null;
+		if (!this._tooltip) return;
+		
+		const destroyTooltips = () => {
+			if (!this._tooltip) return;
+			this._tooltip._destroy();
+			this._tooltip = null;
+		}
+		
+		if (!game.keybindings.get("enhancedcombathud", "pinTooltip").find(keybind => keyboard.downKeys.has(keybind.key))) {
+			//only directly destroy tooltip if pin key is not pressed
+			destroyTooltips();
+		}
+		else {
+			//else delay until pin key is released
+			Hooks.on("argon-releaseTooltip", () => {
+				destroyTooltips();			
+			});
+		}
     }
 
     async render() {


### PR DESCRIPTION
This code would add a key (left alt key by default) to pin the tooltips until the key is released. This might be helpfull in cases where the description of an item includes a link to an effect or another item.