### PR TITLE
Potential bug fix for button panels

### DIFF
--- a/scripts/core/hud.js
+++ b/scripts/core/hud.js
@@ -98,7 +98,7 @@ export class CoreHUD extends Application{
 
   get actionBarWidth() {
     let totalActionBarWidth = 0;
-    this.element[0].querySelectorAll(".actions-container").forEach(element => {
+    this.element[0]?.querySelectorAll(".actions-container").forEach(element => {
       totalActionBarWidth += element.offsetWidth;
     });
     return totalActionBarWidth;


### PR DESCRIPTION
It seems like every so often the below error occurs preventing the macro button panel from rendering. From what i gather that would mean, that the macro button panel tries to open before the html of the argon hud is ready. This change should at least prevent the error from occurring.
![image](https://github.com/theripper93/enhancedcombathud/assets/137942782/0b6c30c4-0578-4dd2-ab84-2280a442faab)
