### PR TITLE
fix: render deprecation logs to console

### DIFF
--- a/scripts/core/components/component.js
+++ b/scripts/core/components/component.js
@@ -134,7 +134,7 @@ export class ArgonComponent {
 
     async _renderInner() {
         const data = await this.getData();
-        const rendered = await renderTemplate(this.template, data);
+        const rendered = await (foundry.applications?.handlebars?.renderTemplate ?? renderTemplate)(this.template, data);
         const tempElement = document.createElement("div");
         tempElement.innerHTML = rendered;
         this.element.innerHTML = tempElement.firstElementChild.innerHTML;

--- a/scripts/core/tooltip.js
+++ b/scripts/core/tooltip.js
@@ -53,7 +53,7 @@ export class Tooltip {
     async _renderInner() {
         const data = await this.getData();
         this._data = data;
-        const rendered = await renderTemplate(this.template, data);
+        const rendered = await (foundry.applications?.handlebars?.renderTemplate ?? renderTemplate) (this.template, data);
         const tempElement = document.createElement("div");
         tempElement.innerHTML = rendered;
         this.element.innerHTML = tempElement.firstElementChild.innerHTML;


### PR DESCRIPTION
I know you are technically not accpeting PRs outside of translations but please consider this extremely minor change to limit the flood of deprecation warnings of "renderTemplate" to console.  This are frequent in v13.

